### PR TITLE
Update resync script to exit if one of the subroutines from File Validator fails

### DIFF
--- a/ci/resync.sh
+++ b/ci/resync.sh
@@ -41,7 +41,10 @@ for attempt in {1..3}; do
     fi
 done
 
-python -m ci.validate_v2 --delete-no-pc 2>&1
+if ! python -m ci.validate_v2 --delete-no-pc 2>&1; then
+    echo "Validation failed. Exiting..."
+    exit 1
+fi
 
 branch_name="resync_$(date +%Y_%m_%d)"
 


### PR DESCRIPTION
Tested it locally:
<img width="888" alt="image" src="https://github.com/user-attachments/assets/e248574c-1531-4d17-a294-e7d7e4ce80a1">
