### PR TITLE
Pin actions/checkout and allow unsafe PR checkout in docs validation

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -14,10 +14,15 @@ jobs:
       codeblock_message: '${{ steps.code_blocks.outputs.codeblock_message }}'
       codeblock_failed: '${{ steps.code_blocks.outputs.codeblock_failed }}'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: '${{ github.event.pull_request.head.sha }}'
           fetch-depth: 0
+          # This workflow intentionally checks out fork PR code under
+          # pull_request_target so the ci/ validation scripts can inspect the
+          # contributed docs. The job runs with permissions: read-all and no
+          # secrets beyond the default token.
+          allow-unsafe-pr-checkout: true
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
The Developer Docs Validation workflow referenced actions/checkout@v4, but GitHub auto-upgrades deprecated major-tag references of official actions at runtime, so the workflow actually runs checkout v7 — which introduces a safety gate that blocks checking out fork PR code in pull_request_target workflows. That is why contributor fork PRs currently fail this check.

Applies the same fix as moveworks-emu/k8s-manifests#17064:

- Pin actions/checkout to the v7.0.1 commit SHA (3d3c42e5...), removing the runtime auto-upgrade variable.
- Set allow-unsafe-pr-checkout: true on the checkout step. It intentionally fetches fork PR code under pull_request_target so the ci/ validation scripts can inspect the contributed docs; the job runs with permissions: read-all and no extra secrets.

The create-github-app-token portion of the upstream PR does not apply — this repo has no such step.